### PR TITLE
Improve Supabase logging and add tests

### DIFF
--- a/app/backend/supabase_logger.py
+++ b/app/backend/supabase_logger.py
@@ -1,12 +1,42 @@
-"""Utility to log conversations to Supabase."""
+"""Asynchronous utility to log conversations to Supabase.
 
+This module provides a small data model and helper function for persisting
+conversation transcripts.  The previous implementation used the synchronous
+``httpx.Client`` which could block the main event loop.  The new version uses an
+``AsyncClient`` and a Pydantic model for stronger typing and easier testing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
 import os
+from typing import Optional
+
 import httpx
-from datetime import datetime
+from pydantic import BaseModel, Field
 
 
-def log_conversation(user_input: str, bot_reply: str) -> None:
-    """Send the conversation details to Supabase if credentials are set."""
+class ConversationLog(BaseModel):
+    """Structured representation of a single conversation exchange."""
+
+    user_input: str
+    bot_reply: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+async def log_conversation(
+    log: ConversationLog, *, client: Optional[httpx.AsyncClient] = None
+) -> None:
+    """Persist ``log`` to Supabase if credentials are available.
+
+    Parameters
+    ----------
+    log:
+        The conversation to persist.
+    client:
+        Optional ``httpx.AsyncClient`` instance.  Primarily used for testing.
+    """
+
     supabase_url = os.getenv("SUPABASE_URL")
     supabase_key = os.getenv("SUPABASE_SERVICE_KEY")
 
@@ -14,23 +44,28 @@ def log_conversation(user_input: str, bot_reply: str) -> None:
         print("⚠️ Supabase credentials missing — skipping log.")
         return
 
-    payload = {
-        "user_input": user_input,
-        "bot_reply": bot_reply,
-        "timestamp": datetime.utcnow().isoformat()
-    }
+    owns_client = False
+    if client is None:
+        client = httpx.AsyncClient(timeout=10.0)
+        owns_client = True
 
     try:
-        with httpx.Client(timeout=10.0) as client:
-            client.post(
-                f"{supabase_url}/rest/v1/conversations",
-                headers={
-                    "apikey": supabase_key,
-                    "Authorization": f"Bearer {supabase_key}",
-                    "Content-Type": "application/json",
-                    "Prefer": "return=minimal"
-                },
-                json=payload
-            )
-    except Exception as e:
+        await client.post(
+            f"{supabase_url}/rest/v1/conversations",
+            headers={
+                "apikey": supabase_key,
+                "Authorization": f"Bearer {supabase_key}",
+                "Content-Type": "application/json",
+                "Prefer": "return=minimal",
+            },
+            json=log.model_dump(mode="json"),
+        )
+    except Exception as e:  # pragma: no cover - network errors just logged
         print(f"Supabase log error: {e}")
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+__all__ = ["ConversationLog", "log_conversation"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,8 @@ python-multipart
 sounddevice
 pydub
 ffmpeg-python
+
+# HTTP client and testing
+httpx
+pytest
+pytest-asyncio

--- a/tests/test_supabase_logger.py
+++ b/tests/test_supabase_logger.py
@@ -1,0 +1,51 @@
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.backend.supabase_logger import ConversationLog, log_conversation
+
+
+@pytest.mark.asyncio
+async def test_log_conversation_posts_payload(monkeypatch):
+    """Ensure the logger posts the expected payload to Supabase."""
+
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "testkey")
+
+    captured = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["json"] = json.loads(request.content.decode())
+        return httpx.Response(201)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        log = ConversationLog(user_input="hi", bot_reply="there")
+        await log_conversation(log, client=client)
+
+    assert (
+        captured["url"]
+        == "https://example.supabase.co/rest/v1/conversations"
+    )
+    assert captured["json"]["user_input"] == "hi"
+    assert captured["json"]["bot_reply"] == "there"
+
+
+@pytest.mark.asyncio
+async def test_log_conversation_skips_without_credentials(monkeypatch, capsys):
+    """Without credentials the logger should exit gracefully."""
+
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+
+    log = ConversationLog(user_input="hi", bot_reply="there")
+    await log_conversation(log)
+
+    captured = capsys.readouterr()
+    assert "Supabase credentials missing" in captured.out
+

--- a/twilio/webhook_handler.py
+++ b/twilio/webhook_handler.py
@@ -1,8 +1,7 @@
-from fastapi import FastAPI, Request, Form
+from fastapi import FastAPI, Form
 from fastapi.responses import Response
-from backend.speak import speak_text
+from agent.speak import speak_text
 from agent.voicebot import coldcall_lead
-import os
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- implement async Supabase logger with Pydantic model
- record conversations from transcribe and SSE endpoints
- fix Twilio webhook imports and add tests

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934ed6d5588329b3c80180010ebcf4