### PR TITLE
feat: add conversation graph and persona utilities

### DIFF
--- a/app/conversation.py
+++ b/app/conversation.py
@@ -1,0 +1,44 @@
+"""Conversation graph utilities for dynamic cold-call scripting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+@dataclass
+class Node:
+    """A node in the conversation graph."""
+
+    message: str
+    transitions: Dict[str, "Node"] = field(default_factory=dict)
+
+    def add_transition(self, user_intent: str, next_node: "Node") -> None:
+        """Map ``user_intent`` to ``next_node``."""
+        self.transitions[user_intent] = next_node
+
+    def next(self, user_intent: str) -> Optional["Node"]:
+        """Return the next node for ``user_intent`` if it exists."""
+        return self.transitions.get(user_intent)
+
+
+class ConversationGraph:
+    """Container for conversation nodes and traversal."""
+
+    def __init__(self, start: Node):
+        self.start = start
+
+    def traverse(self, intents: list[str]) -> list[str]:
+        """Traverse the graph using ``intents`` and collect node messages."""
+        messages = []
+        node: Optional[Node] = self.start
+        for intent in intents:
+            if node is None:
+                break
+            messages.append(node.message)
+            node = node.next(intent)
+        if node is not None:
+            messages.append(node.message)
+        return messages
+
+__all__ = ["Node", "ConversationGraph"]

--- a/app/persona.py
+++ b/app/persona.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass(frozen=True)
+class Persona:
+    """Definition of a calling persona used for voice and style."""
+    name: str
+    voice: str
+    tone: Optional[str] = None
+    pitch: Optional[str] = None
+
+    def system_prompt(self) -> str:
+        """Return a system prompt describing this persona."""
+        desc = [f"You are {self.name} speaking in the {self.voice} voice."]
+        if self.tone:
+            desc.append(f"Your tone is {self.tone}.")
+        if self.pitch:
+            desc.append(f"Your vocal pitch is {self.pitch}.")
+        return " ".join(desc)
+
+__all__ = ["Persona"]

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.conversation import Node, ConversationGraph
+
+
+def build_sample_graph():
+    start = Node("intro")
+    yes_node = Node("great")
+    no_node = Node("maybe next time")
+    start.add_transition("yes", yes_node)
+    start.add_transition("no", no_node)
+    return ConversationGraph(start)
+
+
+def test_traverse_simple_path():
+    graph = build_sample_graph()
+    path = graph.traverse(["yes"])
+    assert path == ["intro", "great"]
+
+
+def test_traverse_missing_intent_stops():
+    graph = build_sample_graph()
+    path = graph.traverse(["maybe"])
+    assert path == ["intro"]

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.persona import Persona
+
+
+def test_system_prompt_includes_details():
+    persona = Persona(name="Ava", voice="warm", tone="friendly")
+    prompt = persona.system_prompt()
+    assert "Ava" in prompt
+    assert "warm" in prompt
+    assert "friendly" in prompt


### PR DESCRIPTION
## Summary
- add persona dataclass to encapsulate caller voice and tone
- introduce conversation graph to support branching call scripts
- cover new utilities with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b3ccde388329a2d40285a668dfc6