### PR TITLE
Make base URL configurable for webhook audio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,5 @@ TWILIO_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_NUMBER=
 LEAD_PHONE=
+APP_BASE_URL=https://your-app.fly.dev
 VOICE_WEBHOOK_URL=https://your-app.fly.dev/twilio-voice

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Key variables and what they are for:
   **Account > Keys & Credentials**.
 - `TWILIO_NUMBER` – the Twilio phone number making calls.
 - `LEAD_PHONE` – the phone number to dial (E.164 format, e.g. `+15551234567`).
+- `APP_BASE_URL` – base URL of your deployed app used for serving audio files.
 - `VOICE_WEBHOOK_URL` – public URL for the bot's voice webhook. When running locally
   you can tunnel your dev server with `ngrok http 8080` and set this to
   `https://<ngrok-id>.ngrok.io/twilio-voice`. If deployed on Fly, use the Fly domain
@@ -108,7 +109,7 @@ To launch the dialer for your vending machine business, follow these steps:
    cp .env.example .env
    ```
 
-   Important variables include `OPENAI_API_KEY`, `ELEVEN_API_KEY`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_NUMBER`, `LEAD_PHONE`, and `VOICE_WEBHOOK_URL`.
+   Important variables include `OPENAI_API_KEY`, `ELEVEN_API_KEY`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_NUMBER`, `LEAD_PHONE`, `APP_BASE_URL`, and `VOICE_WEBHOOK_URL`.
 
 3. **Start the backend server**:
 

--- a/twilio/webhook_handler.py
+++ b/twilio/webhook_handler.py
@@ -1,7 +1,10 @@
+import os
 from fastapi import FastAPI, Form
 from fastapi.responses import Response
 from agent.speak import speak_text
 from agent.voicebot import coldcall_lead
+
+APP_BASE_URL = os.getenv("APP_BASE_URL", "https://your-app.fly.dev")
 
 app = FastAPI()
 
@@ -14,9 +17,10 @@ async def twilio_voice(SpeechResult: str = Form(None)):
         gpt_reply = coldcall_lead([{"role": "user", "content": SpeechResult}])
         speak_text(gpt_reply)  # Saves to /tmp/response.mp3
 
+        play_url = f"{APP_BASE_URL}/audio/response.mp3"
         twiml = f'''
             <Response>
-                <Play>https://your-app.fly.dev/audio/response.mp3</Play>
+                <Play>{play_url}</Play>
                 <Gather input="speech" action="/twilio-voice" method="POST" timeout="5" speechTimeout="auto">
                     <Say>...</Say>
                 </Gather>


### PR DESCRIPTION
## Summary
- read `APP_BASE_URL` env var to build Twilio `<Play>` audio URL
- document `APP_BASE_URL` in example env file and README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a45dfebb4483299d557de0971549b9