### PR TITLE
Ensure Whisper transcription uses file-like input

### DIFF
--- a/agent/listen.py
+++ b/agent/listen.py
@@ -1,11 +1,20 @@
 """Speech-to-text helpers using OpenAI Whisper."""
 
 import openai
+import os
+import tempfile
 
 
 def transcribe_audio(audio_bytes: bytes, sample_rate: int) -> str:
     """Return the transcription text for the given audio."""
     try:
-        return openai.Audio.transcribe("whisper-1", audio_bytes)["text"]
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(audio_bytes)
+            tmp_path = tmp.name
+        try:
+            with open(tmp_path, "rb") as f:
+                return openai.Audio.transcribe("whisper-1", f)["text"]
+        finally:
+            os.remove(tmp_path)
     except Exception as e:
         raise RuntimeError(f"Transcription failed: {str(e)}") from e

--- a/tests/test_listen.py
+++ b/tests/test_listen.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from agent.listen import transcribe_audio
+
+
+def test_transcribe_audio_writes_file_and_calls_openai():
+    audio_bytes = b"audio-data"
+
+    def fake_transcribe(model, file_obj):
+        assert model == "whisper-1"
+        data = file_obj.read()
+        assert data == audio_bytes
+        return {"text": "hello"}
+
+    with patch("openai.Audio.transcribe", side_effect=fake_transcribe) as mock_transcribe:
+        text = transcribe_audio(audio_bytes, sample_rate=16000)
+        assert text == "hello"
+        mock_transcribe.assert_called_once()


### PR DESCRIPTION
## Summary
- Write audio bytes to a temporary file and send a file handle to `openai.Audio.transcribe`
- Add unit test verifying the transcription helper writes the file and calls OpenAI correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a45e0497a48329891f3cb5b5d0acc9