### PR TITLE
Add unit tests for speech and Twilio webhook with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/tests/test_speak.py
+++ b/tests/test_speak.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import requests
+import pytest
+from unittest.mock import Mock
+from agent.speak import speak_text
+
+
+def test_speak_text_success(tmp_path, monkeypatch):
+    mock_response = Mock()
+    mock_response.content = b'audio-data'
+    mock_response.raise_for_status.return_value = None
+
+    def mock_post(url, headers, json):
+        assert url.endswith('/v1/text-to-speech/test-voice')
+        assert headers['xi-api-key'] == 'test-key'
+        assert json['text'] == 'hello'
+        return mock_response
+
+    monkeypatch.setenv('ELEVEN_VOICE_ID', 'test-voice')
+    monkeypatch.setenv('ELEVEN_API_KEY', 'test-key')
+    monkeypatch.setattr(requests, 'post', mock_post)
+
+    out_file = tmp_path / 'out.mp3'
+    result = speak_text('hello', str(out_file))
+
+    assert result == str(out_file)
+    assert out_file.read_bytes() == b'audio-data'
+    mock_response.raise_for_status.assert_called_once()
+
+
+def test_speak_text_failure(monkeypatch):
+    def mock_post(*args, **kwargs):
+        raise requests.exceptions.RequestException('boom')
+
+    monkeypatch.setattr(requests, 'post', mock_post)
+
+    with pytest.raises(RuntimeError) as exc:
+        speak_text('hello')
+    assert 'ElevenLabs TTS failed' in str(exc.value)

--- a/tests/test_twilio_webhook_handler.py
+++ b/tests/test_twilio_webhook_handler.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import types
+from unittest.mock import Mock
+from fastapi.testclient import TestClient
+
+
+def _load_app(monkeypatch):
+    stub = types.ModuleType('agent.voicebot')
+    mock_coldcall = Mock(return_value='AI reply')
+    stub.coldcall_lead = mock_coldcall
+    sys.modules['agent.voicebot'] = stub
+
+    if 'twilio.webhook_handler' in sys.modules:
+        del sys.modules['twilio.webhook_handler']
+    import twilio.webhook_handler as handler
+
+    mock_speak = Mock()
+    monkeypatch.setattr(handler, 'speak_text', mock_speak)
+    return handler.app, mock_coldcall, mock_speak
+
+
+def test_twilio_voice_with_speech(monkeypatch):
+    app, mock_coldcall, mock_speak = _load_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.post('/twilio-voice', data={'SpeechResult': 'hi'})
+    assert resp.status_code == 200
+    assert '<Play>https://your-app.fly.dev/audio/response.mp3</Play>' in resp.text
+    mock_coldcall.assert_called_once_with([{'role': 'user', 'content': 'hi'}])
+    mock_speak.assert_called_once_with('AI reply')
+
+
+def test_twilio_voice_without_speech(monkeypatch):
+    app, mock_coldcall, mock_speak = _load_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.post('/twilio-voice')
+    assert resp.status_code == 200
+    assert 'Taylor from SmartVend' in resp.text
+    mock_coldcall.assert_not_called()
+    mock_speak.assert_not_called()


### PR DESCRIPTION
## Summary
- add unit tests for agent.speak to mock ElevenLabs API and error handling
- add FastAPI TestClient tests for Twilio webhook handler
- add GitHub Actions workflow to run pytest on pushes and PRs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a45e0670e083298f5806c92e13d342