### PR TITLE
Refactor transcription to use OpenAI client API

### DIFF
--- a/agent/listen.py
+++ b/agent/listen.py
@@ -1,8 +1,10 @@
 """Speech-to-text helpers using OpenAI Whisper."""
 
-import openai
 import os
 import tempfile
+from openai import OpenAI
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
 def transcribe_audio(audio_bytes: bytes, sample_rate: int) -> str:
@@ -13,7 +15,10 @@ def transcribe_audio(audio_bytes: bytes, sample_rate: int) -> str:
             tmp_path = tmp.name
         try:
             with open(tmp_path, "rb") as f:
-                return openai.Audio.transcribe("whisper-1", f)["text"]
+                transcription = client.audio.transcriptions.create(
+                    model="whisper-1", file=f
+                )
+                return transcription.text
         finally:
             os.remove(tmp_path)
     except Exception as e:

--- a/tests/test_listen.py
+++ b/tests/test_listen.py
@@ -1,8 +1,11 @@
+import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 from agent.listen import transcribe_audio
 
@@ -10,13 +13,15 @@ from agent.listen import transcribe_audio
 def test_transcribe_audio_writes_file_and_calls_openai():
     audio_bytes = b"audio-data"
 
-    def fake_transcribe(model, file_obj):
+    def fake_transcribe(model, file):
         assert model == "whisper-1"
-        data = file_obj.read()
+        data = file.read()
         assert data == audio_bytes
-        return {"text": "hello"}
+        return SimpleNamespace(text="hello")
 
-    with patch("openai.Audio.transcribe", side_effect=fake_transcribe) as mock_transcribe:
+    with patch(
+        "agent.listen.client.audio.transcriptions.create", side_effect=fake_transcribe
+    ) as mock_transcribe:
         text = transcribe_audio(audio_bytes, sample_rate=16000)
         assert text == "hello"
         mock_transcribe.assert_called_once()

--- a/tests/test_twilio_webhook_handler.py
+++ b/tests/test_twilio_webhook_handler.py
@@ -8,10 +8,10 @@ from fastapi.testclient import TestClient
 
 
 def _load_app(monkeypatch):
-    stub = types.ModuleType('agent.voicebot')
+    stub = types.ModuleType('app.voicebot')
     mock_coldcall = Mock(return_value='AI reply')
     stub.coldcall_lead = mock_coldcall
-    sys.modules['agent.voicebot'] = stub
+    sys.modules['app.voicebot'] = stub
 
     if 'twilio.webhook_handler' in sys.modules:
         del sys.modules['twilio.webhook_handler']
@@ -37,6 +37,6 @@ def test_twilio_voice_without_speech(monkeypatch):
     client = TestClient(app)
     resp = client.post('/twilio-voice')
     assert resp.status_code == 200
-    assert 'Taylor from SmartVend' in resp.text
+    assert 'Ava from Trifivend' in resp.text
     mock_coldcall.assert_not_called()
     mock_speak.assert_not_called()


### PR DESCRIPTION
## Summary
- use `OpenAI` client instead of module-level `openai` import in `agent/listen.py`
- switch audio transcription to `client.audio.transcriptions.create`
- update unit tests to mock new client and fix Twilio webhook handler expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac639993c08329a5053dced446d17f