### PR TITLE
Add timeout option for ElevenLabs TTS

### DIFF
--- a/agent/speak.py
+++ b/agent/speak.py
@@ -3,7 +3,12 @@
 import os
 import requests
 
-def speak_text(text: str, output_path: str = "/tmp/response.mp3") -> str:
+
+def speak_text(
+    text: str,
+    output_path: str = "/tmp/response.mp3",
+    timeout: float = 10.0,
+) -> str:
     """Convert ``text`` to speech and save it to ``output_path``.
 
     Parameters
@@ -12,6 +17,8 @@ def speak_text(text: str, output_path: str = "/tmp/response.mp3") -> str:
         The text to convert to speech.
     output_path:
         Where the resulting MP3 should be written. Defaults to ``/tmp/response.mp3``.
+    timeout:
+        Number of seconds to wait for the ElevenLabs API response. Defaults to 10 seconds.
 
     Returns
     -------
@@ -36,7 +43,7 @@ def speak_text(text: str, output_path: str = "/tmp/response.mp3") -> str:
     }
 
     try:
-        response = requests.post(url, headers=headers, json=data)
+        response = requests.post(url, headers=headers, json=data, timeout=timeout)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
         raise RuntimeError(f"ElevenLabs TTS failed: {str(e)}") from e

--- a/tests/test_speak.py
+++ b/tests/test_speak.py
@@ -14,10 +14,11 @@ def test_speak_text_success(tmp_path, monkeypatch):
     mock_response.content = b'audio-data'
     mock_response.raise_for_status.return_value = None
 
-    def mock_post(url, headers, json):
+    def mock_post(url, headers, json, timeout=None):
         assert url.endswith('/v1/text-to-speech/test-voice')
         assert headers['xi-api-key'] == 'test-key'
         assert json['text'] == 'hello'
+        assert timeout == 10.0
         return mock_response
 
     monkeypatch.setenv('ELEVEN_VOICE_ID', 'test-voice')


### PR DESCRIPTION
## Summary
- Add optional `timeout` parameter to `agent.speak.speak_text`
- Pass timeout to `requests.post`
- Update tests for new timeout parameter

## Testing
- `pytest tests/test_speak.py -q`
- `pytest -q` *(fails: AI response failed, assertion mismatch in webhook handler)*

------
https://chatgpt.com/codex/tasks/task_e_68ac639bed448329b85bc7d952316ec9