### PR TITLE
Add lead model and conversation logging

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -60,6 +60,7 @@ async def test_sse_concurrent(monkeypatch):
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         params = {
             "lead_name": "a",
+            "phone": "123",
             "property_type": "b",
             "location_area": "c",
             "callback_offer": "d",

--- a/twilio/webhook_handler.py
+++ b/twilio/webhook_handler.py
@@ -36,7 +36,7 @@ async def twilio_voice(SpeechResult: str = Form(None)):
         # Initial greeting or re-entry point
         twiml = '''
             <Response>
-                <Say>Hi, this is Taylor from SmartVend. I wanted to quickly ask about your vending machine setup. Are you the right person to speak with?</Say>
+                <Say>Hi, this is Ava from Trifivend. I wanted to quickly ask about your vending machine setup. Are you the right person to speak with?</Say>
                 <Gather input="speech" action="/twilio-voice" method="POST" timeout="5" speechTimeout="auto">
                     <Say>I'm listening...</Say>
                 </Gather>

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -71,6 +71,7 @@ if st.button("Send"):
 
 st.subheader("Stream from /mcp/sse")
 lead_name = st.text_input("Lead name", "Alex", key="lead")
+lead_phone = st.text_input("Phone number", "123-456-7890", key="phone")
 property_type = st.text_input("Property type", "apartment", key="ptype")
 location_area = st.text_input("Location area", "NYC", key="loc")
 callback_offer = st.text_input("Callback offer", "schedule a demo", key="offer")
@@ -80,6 +81,7 @@ if st.button("Start SSE Stream"):
     collected = ""
     params = {
         "lead_name": lead_name,
+        "phone": lead_phone,
         "property_type": property_type,
         "location_area": location_area,
         "callback_offer": callback_offer,


### PR DESCRIPTION
## Summary
- add `Lead` model and Supabase logging helper
- stream and log final SSE transcripts with associated lead info
- extend Streamlit UI to capture lead details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac6b282eac83298657af0d7a3e962c