### PR TITLE
Route Streamlit through Fly backend for calls and streaming

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -67,7 +67,7 @@ async def test_sse_concurrent(monkeypatch):
         }
 
         async def get():
-            resp = await client.get("/mcp/sse", params=params)
+            resp = await client.get("/sse", params=params)
             assert resp.status_code == 200
             assert "hello" in resp.text
 

--- a/tests/test_twilio_webhook_handler.py
+++ b/tests/test_twilio_webhook_handler.py
@@ -15,6 +15,7 @@ def _load_app(monkeypatch):
 
     if 'twilio.webhook_handler' in sys.modules:
         del sys.modules['twilio.webhook_handler']
+    sys.modules.pop('twilio', None)
     import twilio.webhook_handler as handler
 
     mock_speak = Mock()


### PR DESCRIPTION
## Summary
- Add Twilio call initiation, management endpoints, and voice webhook to FastAPI
- Replace hardcoded localhost URLs in Streamlit with Fly backend URL and call controls via backend
- Align tests with new /sse route and local webhook handler import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac68033b9c8329987477ae0183c622