### PR TITLE
Potential fix for code scanning alert no. 3: Prototype-polluting assignment

### DIFF
--- a/venv/lib/python3.10/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
+++ b/venv/lib/python3.10/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
@@ -5,19 +5,19 @@ let Status = {
   ERROR_EXCEPTION: -4,
 };
 
-let connections = {};
+let connections = new Map();
 let nextConnectionID = 1;
 const encoder = new TextEncoder();
 
 self.addEventListener("message", async function (event) {
   if (event.data.close) {
     let connectionID = event.data.close;
-    delete connections[connectionID];
+    connections.delete(connectionID);
     return;
   } else if (event.data.getMore) {
     let connectionID = event.data.getMore;
     let { curOffset, value, reader, intBuffer, byteBuffer } =
-      connections[connectionID];
+      connections.get(connectionID);
     // if we still have some in buffer, then just send it back straight away
     if (!value || curOffset >= value.length) {
       // read another buffer if required
@@ -26,7 +26,7 @@ self.addEventListener("message", async function (event) {
 
         if (readResponse.done) {
           // read everything - clear connection and return
-          delete connections[connectionID];
+          connections.delete(connectionID);
           Atomics.store(intBuffer, 0, Status.SUCCESS_EOF);
           Atomics.notify(intBuffer, 0);
           // finished reading successfully
@@ -34,7 +34,13 @@ self.addEventListener("message", async function (event) {
           return;
         }
         curOffset = 0;
-        connections[connectionID].value = readResponse.value;
+        {
+          const conn = connections.get(connectionID);
+          if (conn) {
+            conn.value = readResponse.value;
+            connections.set(connectionID, conn);
+          }
+        }
         value = readResponse.value;
       } catch (error) {
         console.log("Request exception:", error);
@@ -57,7 +63,13 @@ self.addEventListener("message", async function (event) {
     Atomics.store(intBuffer, 0, curLen); // store current length in bytes
     Atomics.notify(intBuffer, 0);
     curOffset += curLen;
-    connections[connectionID].curOffset = curOffset;
+    {
+      const conn = connections.get(connectionID);
+      if (conn) {
+        conn.curOffset = curOffset;
+        connections.set(connectionID, conn);
+      }
+    }
 
     return;
   } else {
@@ -84,13 +96,13 @@ self.addEventListener("message", async function (event) {
       byteBuffer.set(headerBytes);
       intBuffer[1] = written;
       // make a connection
-      connections[connectionID] = {
+      connections.set(connectionID, {
         reader: response.body.getReader(),
         intBuffer: intBuffer,
         byteBuffer: byteBuffer,
         value: undefined,
         curOffset: 0,
-      };
+      });
       // set header ready
       Atomics.store(intBuffer, 0, Status.SUCCESS_HEADER);
       Atomics.notify(intBuffer, 0);


### PR DESCRIPTION
Potential fix for [https://github.com/FritzHeider/Trifivend/security/code-scanning/3](https://github.com/FritzHeider/Trifivend/security/code-scanning/3)

To fix this, we must prevent prototype pollution when using untrusted keys for object property assignment within `connections`. There are two standard approaches, both recommended in the CodeQL background:

1. Use a `Map` object instead of a plain JavaScript object for `connections`. Map is resilient to prototype pollution because its keys are not interpreted as properties, and you can't pollute the prototype using a Map.
2. Alternatively, sanitize/validate `connectionID` before using it as a key, ensuring it is neither `"__proto__"`, `"constructor"`, nor `"prototype"` (or, ideally, matches only allowed patterns).

The most robust and least disruptive fix is to convert `connections` to a `Map`. This is simple because all object-style accesses (set, get, delete) are in the code shown and use the same variable. The resulting changes:
- Change `let connections = {};` to `let connections = new Map();`
- Replace all `connections[connectionID]` with `connections.get(connectionID)` (for reads), `connections.set(connectionID, ...)` (for writes), and `delete connections[connectionID]` with `connections.delete(connectionID)`.
- Adjust assignments like `connections[connectionID].curOffset = curOffset` to instead get the object, assign to `curOffset`, then set it back using `.set`.

No external dependencies are required; `Map` is a core built-in object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
