### PR TITLE
Enable streaming cold-call responses over Twilio

### DIFF
--- a/agent/speak.py
+++ b/agent/speak.py
@@ -1,6 +1,13 @@
 """Utility for converting text to speech using ElevenLabs."""
 
+from __future__ import annotations
+
 import os
+from collections.abc import AsyncGenerator
+from typing import Optional
+
+import aiofiles
+import httpx
 import requests
 
 
@@ -52,3 +59,77 @@ def speak_text(
         f.write(response.content)
 
     return output_path
+
+
+async def stream_text_to_speech(
+    text: str,
+    *,
+    output_path: str = "/tmp/response.mp3",
+    voice_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+    stability: float = 0.4,
+    similarity_boost: float = 0.7,
+    append: bool = False,
+    client: Optional[httpx.AsyncClient] = None,
+) -> AsyncGenerator[bytes, None]:
+    """Stream ElevenLabs audio while persisting it to disk.
+
+    Parameters
+    ----------
+    text:
+        Text to synthesise.
+    output_path:
+        Target file for the resulting MP3 chunks.
+    voice_id / api_key:
+        Optional overrides for environment configuration.
+    append:
+        When ``True`` the audio is appended to ``output_path`` instead of
+        overwriting it (useful for multi-request pipelines).
+    client:
+        Optional shared ``httpx.AsyncClient``.
+    """
+
+    resolved_voice = voice_id or os.getenv("ELEVEN_VOICE_ID", "Rachel")
+    resolved_key = api_key or os.getenv("ELEVEN_API_KEY")
+
+    if not resolved_key:
+        raise RuntimeError("ELEVEN_API_KEY is not configured")
+
+    url = f"https://api.elevenlabs.io/v1/text-to-speech/{resolved_voice}/stream"
+    headers = {
+        "xi-api-key": resolved_key,
+        "Content-Type": "application/json",
+        "Accept": "audio/mpeg",
+    }
+    payload = {
+        "text": text,
+        "voice_settings": {
+            "stability": stability,
+            "similarity_boost": similarity_boost,
+        },
+    }
+
+    dirname = os.path.dirname(output_path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+
+    owns_client = False
+    if client is None:
+        client = httpx.AsyncClient(timeout=httpx.Timeout(60.0))
+        owns_client = True
+
+    mode = "ab" if append else "wb"
+    try:
+        async with client.stream("POST", url, headers=headers, json=payload) as resp:
+            resp.raise_for_status()
+            async with aiofiles.open(output_path, mode) as file_obj:
+                async for chunk in resp.aiter_bytes():
+                    if not chunk:
+                        continue
+                    await file_obj.write(chunk)
+                    yield chunk
+    except Exception as e:  # pragma: no cover - network errors surface upstream
+        raise RuntimeError(f"ElevenLabs streaming TTS failed: {str(e)}") from e
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/app/voicebot.py
+++ b/app/voicebot.py
@@ -1,21 +1,103 @@
 """Simple wrapper around the OpenAI Chat API used for lead engagement."""
 
+from __future__ import annotations
+
+import asyncio
 import os
-from openai import OpenAI
+from collections.abc import AsyncGenerator, Sequence
+from typing import List, MutableSequence
+
+from openai import AsyncOpenAI
 
 MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4")
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+async_client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+_SENTENCE_DELIMITERS = (".", "?", "!", "\n")
+_MAX_BUFFER_CHARS = 300
 
 
-def coldcall_lead(messages: list, temperature: float = 0.7, model: str = MODEL_NAME) -> str:
-    """Return the assistant's reply for the provided chat ``messages``."""
+async def stream_coldcall_reply(
+    messages: Sequence[dict],
+    *,
+    temperature: float = 0.7,
+    model: str = MODEL_NAME,
+) -> AsyncGenerator[str, None]:
+    """Yield incremental text responses from the assistant.
+
+    The function mirrors the batching strategy used by the websocket voice agent:
+    as tokens are received they are accumulated until a sentence boundary (or a
+    safety length) is observed, at which point the buffered text is yielded.
+    """
+
+    buffer = ""
     try:
-        response = client.chat.completions.create(
+        response = await async_client.chat.completions.create(
             model=model,
-            messages=messages,
+            messages=list(messages),
             temperature=temperature,
+            stream=True,
         )
-        return response.choices[0].message.content
+
+        async for chunk in response:
+            if not chunk.choices:
+                continue
+            delta = getattr(chunk.choices[0].delta, "content", None)
+            if not delta:
+                continue
+
+            buffer += delta
+            if any(delim in buffer for delim in _SENTENCE_DELIMITERS) or len(buffer) > _MAX_BUFFER_CHARS:
+                flushed, buffer = buffer.strip(), ""
+                if flushed:
+                    yield flushed
+
+    except Exception as e:  # pragma: no cover - network exceptions are surfaced upstream
+        raise RuntimeError(f"AI streaming response failed: {str(e)}") from e
+
+    if buffer.strip():
+        yield buffer.strip()
+
+
+async def _collect_reply(
+    messages: Sequence[dict],
+    *,
+    temperature: float = 0.7,
+    model: str = MODEL_NAME,
+) -> str:
+    parts: MutableSequence[str] = []
+    async for part in stream_coldcall_reply(
+        messages, temperature=temperature, model=model
+    ):
+        parts.append(part)
+    return " ".join(parts).strip()
+
+
+def coldcall_lead(
+    messages: List[dict],
+    temperature: float = 0.7,
+    model: str = MODEL_NAME,
+) -> str:
+    """Return the assistant's reply for the provided chat ``messages``.
+
+    This synchronous helper is retained for legacy callers (tests, background
+    utilities).  It internally consumes the streaming generator via ``asyncio``.
+    """
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():  # pragma: no cover - defensive, not expected in tests
+        raise RuntimeError(
+            "coldcall_lead() cannot be called from a running event loop; use "
+            "`stream_coldcall_reply` instead."
+        )
+
+    try:
+        return asyncio.run(
+            _collect_reply(messages, temperature=temperature, model=model)
+        )
     except Exception as e:
         raise RuntimeError(f"AI response failed: {str(e)}") from e
 


### PR DESCRIPTION
## Summary
- expose an async `stream_coldcall_reply` generator so GPT responses can be consumed incrementally
- add an ElevenLabs streaming TTS helper and wire Twilio voice handling to feed audio chunks via a new `/audio/response-stream` endpoint
- update the Twilio pipeline to stream audio/logging from background tasks while preserving SSE analytics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb8d72233083298b39e7b581f4a50a