### PR TITLE
Use gpt-4o-mini as default voicebot model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ TWILIO_NUMBER=+1XXXXXXXXXX
 
 # OpenAI
 OPENAI_API_KEY=sk-...
+OPENAI_MODEL=gpt-4o-mini
 
 # Supabase (optional logging)
 SUPABASE_URL=https://YOURPROJECT.supabase.co

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cp .env.example .env
 Key variables and what they are for:
 
 - `OPENAI_API_KEY` – OpenAI API key.
-- `OPENAI_MODEL` – model to use (default `gpt-4`).
+- `OPENAI_MODEL` – model to use (default `gpt-4o-mini`; faster models are recommended for live calls).
 - `ELEVEN_API_KEY` – ElevenLabs API key for TTS.
 - `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` – optional Supabase logging.
 - `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` – found in the Twilio console under

--- a/app/voicebot.py
+++ b/app/voicebot.py
@@ -3,7 +3,7 @@
 import os
 from openai import OpenAI
 
-MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4")
+MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 


### PR DESCRIPTION
## Summary
- default the voice bot's OpenAI model to `gpt-4o-mini` while keeping the environment override
- add the model to `.env.example` and document the new default in the README along with guidance on using faster models for live calls

## Testing
- `pytest tests/test_twilio_webhook_handler.py`
- `pytest tests/test_concurrency.py` *(fails: `IndentationError` importing `main.py`, reproduced on `work` branch)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8d7504dc832997d74a2c1bc2cbce