### PR TITLE
Ensure container defaults to serving API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,17 @@ RUN python -m pip install --upgrade pip && \
 COPY . /app
 ENV PYTHONPATH=/app
 
+# Copy a lightweight entrypoint that defaults to serving the API. The script
+# respects any explicit command provided by Fly's [processes] config, making
+# the same image usable for both the API and UI deployments.
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 # Expose for clarity (Fly uses internal_port anyway)
 EXPOSE 8080
 
-# Do NOT start the app here; Fly [processes] runs it (uvicorn via fly.api.toml)
-# No CMD/ENTRYPOINT needed — keeps image reusable for API/UI
+# Default to running the FastAPI app. When Fly's [processes] provides a command
+# (e.g. the Streamlit UI), the entrypoint simply execs that command instead.
+ENTRYPOINT ["/entrypoint.sh"]
+CMD []
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
+PORT="${PORT:-8080}"
+exec uvicorn main:app --host 0.0.0.0 --port "$PORT"


### PR DESCRIPTION
## Summary
- add a reusable Docker entrypoint that runs uvicorn on the configured PORT when no command is supplied
- wire the Dockerfile to install the entrypoint so the Fly deployment always listens on 0.0.0.0:8080 by default

## Testing
- PORT=9000 ./docker-entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d93c3fec8483298415c4d85c463746