### PR TITLE
Handle string commands in entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,11 @@
 set -e
 
 if [ "$#" -gt 0 ]; then
-  exec "$@"
+  if [ "$#" -eq 1 ]; then
+    exec sh -c "$1"
+  else
+    exec "$@"
+  fi
 fi
 
 PORT="${PORT:-8080}"


### PR DESCRIPTION
## Summary
- update the Docker entrypoint to run single string commands through `sh -c` so Fly-provided command strings work while preserving existing exec behavior for tokenized arguments

## Testing
- ./docker-entrypoint.sh "echo hi"


------
https://chatgpt.com/codex/tasks/task_e_68d94446ccc083298827a10e6af3faf4