### PR TITLE
Install backend requirements in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,21 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl bash && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy requirements if you have it; fall back to inline install
-# If you use a requirements.txt, uncomment the next two lines:
-# COPY requirements.txt .
-# RUN pip install -r requirements.txt
+# Copy backend requirements and install the full dependency set
+COPY requirements.backend.txt ./requirements.backend.txt
 
-# Install minimal runtime deps (FastAPI/uvicorn are required)
 RUN python -m pip install --upgrade pip && \
-    pip install \
-      fastapi==0.115.0 \
-      uvicorn[standard]==0.30.6 \
-      python-dotenv==1.0.1 \
-      sse-starlette==2.1.3 \
-      pydantic==2.9.2 \
-      pydantic-settings==2.5.2 \
-      twilio==9.3.7
+    pip install --no-cache-dir -r requirements.backend.txt
 
 # Copy app
 # If your module is in /app (i.e., main.py at project root), copy everything;


### PR DESCRIPTION
## Summary
- copy the backend requirements file into the Docker image build context
- install the full backend dependency set during the image build to support FastAPI features

## Testing
- make deploy-both *(fails: `fly` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd262373a4832994df57de23122546