### PR TITLE
Fix Twilio webhook base URL fallback handling

### DIFF
--- a/twilio_utils/webhook_handler.py
+++ b/twilio_utils/webhook_handler.py
@@ -1,14 +1,26 @@
 import os
+
 from fastapi import FastAPI, Form
 from fastapi.responses import Response
 from fastapi.concurrency import run_in_threadpool
+
 from agent.speak import speak_text
+
 try:
     from app.voicebot import coldcall_lead
 except ImportError:  # pragma: no cover - fallback for production
     from app.voicebot import coldcall_lead
 
-APP_BASE_URL = os.getenv("APP_BASE_URL", "https://ai-callbot.fly.dev")
+
+def _resolve_app_base_url() -> str:
+    """Return the base URL the webhook should use for generated audio."""
+
+    default_base = "https://your-app.fly.dev"
+    raw = os.getenv("APP_BASE_URL", "").strip()
+    return (raw or default_base).rstrip("/")
+
+
+APP_BASE_URL = _resolve_app_base_url()
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- make the Twilio webhook use the placeholder Fly domain when APP_BASE_URL is unset
- add a helper that normalizes the configured base URL before generating audio links

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd6efd3c808329aeab6360cbe53ffd