### PR TITLE
Install backend dependencies during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy backend requirements and install the full dependency set
 COPY requirements.backend.txt ./requirements.backend.txt
 
-RUN python -m pip install --upgrade pip && \
+RUN python -m pip install --upgrade pip setuptools wheel && \
     pip install --no-cache-dir -r requirements.backend.txt
 
 # Copy app


### PR DESCRIPTION
## Summary
- ensure the Docker image upgrades pip/setuptools/wheel before installing the backend dependency lockfile

## Testing
- make deploy-both *(fails: `fly` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de88e589148329b1a48278e7f637c1